### PR TITLE
不讓 API 本身暴露

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,19 +3,5 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo'],
     plugins: ["nativewind/babel"],
-    presets: ['module:metro-react-native-babel-preset'],
-    plugins: [
-      [
-        'module:react-native-dotenv', 
-        {
-          moduleName: '@env',
-          path: '.env',
-          blacklist: null,
-          whitelist: null,
-          safe: false,
-          allowUndefined: true
-        }
-      ]
-    ]
   };
 };


### PR DESCRIPTION
用 .env 將 api 包裹
再使用 expo-constants  讓 app.json 可以 "${GOOGLE_MAPS_API_KEY}"